### PR TITLE
Add thermoelastic example

### DIFF
--- a/examples/user/thermoelasticity.yaml
+++ b/examples/user/thermoelasticity.yaml
@@ -9,7 +9,7 @@ description: |
   As the resulting temperature - a homogeneous field - is known, the temperature
   equation does not need to be solved. 
   More information regarding the theory of elasticity and thermoelasticity 
-  can be found in, for example, ["Elasticity - Therory, Application and 
+  can be found in, for example, ["Elasticity - Theory, Applications and 
   Numerics" by M. Sadd][Sadd2014]
 
   [Sadd2014]: https://doi.org/10.1016/C2012-0-06981-5
@@ -18,7 +18,6 @@ commit: 8dac5338ca03b2d61145f1261144346e1d5d14ea
 script: thermoelastic-example.py
 images:
   - displacement.png
-  - deformed_cylinder.vtk
 tags:
   - solid mechanics
   - NURBS

--- a/examples/user/thermoelasticity.yaml
+++ b/examples/user/thermoelasticity.yaml
@@ -1,0 +1,24 @@
+name: Thermoelastic deformation of NURBS cylinder
+authors:
+  - Roxana Pohlmann
+description: |
+  This example considers the thermal deformation of a hollow 
+  cylinder. First, a heat problem is solved, where the temperature from the 
+  boundary diffuses into the inner cylinder. The solution to this problem 
+  is used as the initial temperature in a linear thermoelastic problem. 
+  As the resulting temperature - a homogeneous field - is known, the temperature
+  equation does not need to be solved. 
+  More information regarding the theory of elasticity and thermoelasticity 
+  can be found in, for example, ["Elasticity - Theory, Applications and 
+  Numerics" by M. Sadd][Sadd2014]
+
+  [Sadd2014]: https://doi.org/10.1016/C2012-0-06981-5
+repository: https://github.com/Roxana-P/nutils-thermoelastic.git
+commit: 8dac5338ca03b2d61145f1261144346e1d5d14ea
+script: thermoelastic-example.py
+images:
+  - displacement.png
+tags:
+  - solid mechanics
+  - NURBS
+  - thermal

--- a/examples/user/thermoelasticity.yaml
+++ b/examples/user/thermoelasticity.yaml
@@ -1,0 +1,25 @@
+name: Thermoelastic deformation of NURBS cylinder
+authors:
+  - Roxana Pohlmann
+description: |
+  This example considers the thermal deformation of a hollow 
+  cylinder. First, a heat problem is solved, where the temperature from the 
+  boundary diffuses into the inner cylinder. The solution to this problem 
+  is used as the initial temperature in a linear thermoelastic problem. 
+  As the resulting temperature - a homogeneous field - is known, the temperature
+  equation does not need to be solved. 
+  More information regarding the theory of elasticity and thermoelasticity 
+  can be found in, for example, ["Elasticity - Therory, Application and 
+  Numerics" by M. Sadd][Sadd2014]
+
+  [Sadd2014]: https://doi.org/10.1016/C2012-0-06981-5
+repository: https://github.com/Roxana-P/nutils-thermoelastic.git
+commit: 8dac5338ca03b2d61145f1261144346e1d5d14ea
+script: thermoelastic-example.py
+images:
+  - displacement.png
+  - deformed_cylinder.vtk
+tags:
+  - solid mechanics
+  - NURBS
+  - thermal


### PR DESCRIPTION
The pull-requests contains an example for thermoelastic material behavior and shows the following:

1. Creation of a periodic 3D NURBS
2. Solution of the instationary heat equation. 
3. Solution of the thermoelastic problem, with initial values derived from the heat equation. 
4. Export to matplotlib and vtk 

While the physical problem is very simple, the code gives examples for the following features

- vtk export
- using a field instead of a function as initial values 
- NURBS basis in 1D and 2D


