### PR TITLE
use last i/o first image as thumnail

### DIFF
--- a/examples/official/adaptivity.yaml
+++ b/examples/official/adaptivity.yaml
@@ -13,7 +13,7 @@ description: |
   restored by using adaptive refinement.
 script: examples/adaptivity.py
 images:
-  - sol.png
   - err.png
+  - sol.png
 tags:
   - adaptive refinements

--- a/examples/official/finitestrain.yaml
+++ b/examples/official/finitestrain.yaml
@@ -8,7 +8,7 @@ description: |
 branch: release/6
 script: examples/finitestrain.py
 images:
-  - nonlinear.png
   - linear.png
+  - nonlinear.png
 tags:
   - finite strain

--- a/src/main.rs
+++ b/src/main.rs
@@ -262,7 +262,7 @@ fn build_website() {
 
         examples_list.push(ExampleListContext {
             name: metadata.name.to_string(),
-            thumbnail: if let Some(image) = images.iter().next() {
+            thumbnail: if let Some(image) = images.iter().last() {
                 Some(format!("{}/{}", id, image))
             } else {
                 None


### PR DESCRIPTION
This patch changes the thumbnail image from the first to the last of the provided series, and updates two examples accordingly. The rationale behind this change is that scripts often build up in complexity leading the last image to be the most impressive. While this last image could simply be listed first to make it the thumbnail, the side effect of this is that the detailed view shows images in counter-logical order. In the finite strain exampe, for instance, the result of the nonlinear problem is awkwardly followed by the intermediate result of the linear problem. This patch restores natural left-to-right progression for this type of situation.